### PR TITLE
Feature/smp granular locks v4

### DIFF
--- a/granular_locks_v4.md
+++ b/granular_locks_v4.md
@@ -1,0 +1,411 @@
+# Introduction
+
+Currently, the SMP FreeRTOS kernel implements critical section using a "Global locking" approach, where all data is protected by a pair of spinlocks (namely the Task Lock and ISR Lock). This means that every critical section contests for this pair of spinlocks, even if those critical sections access unrelated/orthogonal data.
+
+The goal of this proposal is to use granular or localized spinlocks so that concurrent access to different data groups do no contest for the same spinlocks. This will reduce lock contention and hopefully increase performance of the SMP FreeRTOS kernel.
+
+This proposal describes a **"Dual Spinlock With Data Group Locking"** approach to granular locking.
+
+Source code changes are based off release V11.1.0 of the FreeRTOS kernel.
+
+# Data Groups
+
+To make the spinlocks granular, FreeRTOS data will be organized into the following data groups, where each data group is protected by their own set of spinlocks.
+
+- Kernel Data Group
+  - All data in `tasks.c` and all event lists (e.g., `xTasksWaitingToSend` and `xTasksWaitingToReceive` in the queue objects)
+- Queue Data Group
+  - Each queue object (`Queue_t`) is its own data group (excluding the task lists)
+- Event Group Data Group
+  - Each event group object (`EventGroup_t`) is its own data group (excluding the task lists)
+- Stream Buffer Data Group
+  - Each stream buffer object (`StreamBuffer_t`) is its own data group (excluding the task lists)
+- Timers
+  - All data in `timers.c` and timer objects,  belong to the same Timer Data Group
+- User/Port Data Groups
+  - The user and ports are free to organize their own data in to data groups of their choosing
+
+# Dual Spinlock With Data Group Locking
+
+The **"Dual Spinlock With Data Group Locking"** uses a pair of spinlocks to protect each data group (namely the `xTaskSpinlock` and `xISRSpinlock` spinlocks).
+
+```c
+typedef struct
+{
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        portSPINLOCK_TYPE xTaskSpinlock;
+        portSPINLOCK_TYPE xISRSpinlock;
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+} xSomeDataGroup_t;
+```
+
+However, each data group must also allow for non-deterministic access with interrupts **enabled** by providing a pair of lock/unlock functions. These functions must block access to other tasks trying to access members of a data group and must pend access to ISRs trying to access members of the data group.
+
+```c
+static void prvLockSomeDataGroupForTasks( xSomeDataGroup_t * const pxSomDataGroup );
+static void prvUnlockSomeDataGroupForTasks( xSomeDataGroup_t * const pxSomDataGroup );
+```
+
+In simple terms, the "Dual Spinlock With Data Group Locking" is an extension is the existing dual spinlock (i.e., Task and ISR spinlock) approach used in the SMP FreeRTOS kernel, but replicated across different data groups.
+
+## Data Group Critical Sections (Granular Locks)
+
+A critical section for a data group can be achieved as follows:
+
+- When entering a data group critical section from a task
+  1. Disable interrupts
+  2. Take `xTaskSpinlock` of data group
+  3. Take `xISRSpinlock` of data group
+  4. Increment nesting count
+- When entering data group critical section from an ISR
+  1. Disable interrupts
+  2. Take `xISRSpinlock` of data group
+  3. Increment nesting count
+
+When exiting a data group critical section, the procedure is reversed. Furthermore, since yield requests are pended when inside a critical section, exiting a task critical section will also need to handle any pended yields.
+
+- When exiting a data group critical section from a task
+  1. Release `xISRSpinlock` of data group
+  2. Release `xTaskSpinlock` of data group
+  3. Decrement nesting count
+  4. Reenable interrupts if nesting count is 0
+  5. Trigger yield if there is a yield pending
+- When exiting data group critical section form an ISR
+  1. Release `xISRSpinlock` of data group
+  2. Decrement nesting count
+  3. Reenable interrupts if nesting count is 0
+
+Entering multiple data group critical sections in a nested manner is permitted. This means, if a code path has already entered a critical section in data group A, it can then enter a critical section in data group B. This is analogous to nested critical sections. However, care must be taken to avoid deadlocks. This can be achieved by organizing data groups into a hierarchy, where a higher layer data group cannot nest into a lower one.
+
+```
+                                           +-------------------+
+                                           | Kernel Data Group |
+                                           +-------------------+
+
+  +-------------------+  +---------------------------+ +--------------------------+ +------------------+
+  | Queue Data Groups |  | Stream Buffer Data Groups | | Event Groups Data Groups | | Timer Data Group |
+  +-------------------+  +---------------------------+ +--------------------------+ +------------------+
+
++------------------------------------------------------------------------------------------------------+
+|                                            User Data Groups                                          |
++------------------------------------------------------------------------------------------------------+
+```
+
+If nested locking only occurs from bottom up (e.g., User data group can nested into a Queue data group which in turn can nested into Kernel data group), then deadlocking will never occur.
+
+## Data Group Locking
+
+FreeRTOS does not permit walking linked lists while interrupts are disabled to ensure deterministic ISR latency. Therefore, each data group must provide a method of locking so that non-deterministic operations can be executed for a data group. While a data group is locked:
+
+- Preemption is disabled for the current task
+- Interrupts remained enabled
+- The data group's `xTaskSpinlock` is taken to prevent tasks running on other cores from accessing the data group
+- Any ISR that attempts to update the data group will have their access pended. These pended accesses will be handled on resumption
+
+The logic of suspending a data group is analogous to the logic of `vTaskSuspendAll()`/`xTaskResumeAll()` and `prvLockQueue()`/`prvUnlockQueue()` in the existing SMP kernel.
+
+The details of how ISR accesses are pended during suspension will be specific to each data group type, thus the implementation of the suspend/resumption functions also be specified to each data group type. However, the procedure for data group suspension and resumption will typically be as follows:
+
+- Suspension
+  1. Disable preemption
+  2. Lock the data group
+  3. Set a suspension flag that indicates the data group is suspended
+  4. Unlock the data group, but keep holding `xTaskSpinlock`
+- Resumption
+  1. Lock the data group
+  2. Clear the suspension flag
+  3. Handle all pended accesses from ISRs
+  4. Unlock the data group, thus releasing `xTaskSpinlock`
+
+Locking multiple data groups in a nested manner is permitted, meaning if a code path has already locked data group A, it can then lock data group B. This is analogous to nested `vTaskSuspendAll()` calls. Similar to data group locking, deadlocks can be avoided by organizing data groups into a hierarchy.
+
+## Thread Safety Check
+
+Under SMP, there are four sources of concurrent access for a particular data group:
+
+- Preempting task on the same core
+- Preempting ISR on the same core
+- Concurrent task on another core
+- Concurrent ISR on another core
+
+This section checks that the data group critical section and locking mechanisms mentioned, ensure thread safety from each concurrent source of access.
+
+- Data Group Critical Section from tasks: Interrupts are disabled, `xTaskSpinlock` and `xISRSpinlock` are taken
+  - Task (same core): Context switch cannot occur because interrupts are disabled
+  - Task (other cores): The task will spin on `xTaskSpinlock`
+  - ISR (same core): Interrupts on the current core are disabled
+  - ISR (other cores): ISR will spin on `xISRSpinlock`
+
+- Data Group Critical Sections from ISRs: Interrupts are disabled, `xISRSpinlock` is taken
+  - Task (same core): Context switch cannot occur because we are in an ISR
+  - Task (other cores): The task will spin on `xISRSpinlock`
+  - ISR (same core): Interrupts on the current core are disabled
+  - ISR (other cores): ISR will spin on `xISRSpinlock`
+
+- Data Group Locking from tasks: Preemption is disabled, `xTaskSpinlock` is taken
+  - Task (same core): Context switch cannot occur because preemption is disabled
+  - Task (other cores): The task will spin on `xTaskSpinlock`
+  - ISR (same core): Critical section is entered because `xISRSpinlock` is not held, but access is pended
+  - ISR (other cores): Critical section is entered because `xISRSpinlock` is not held, but access is pended
+
+# Public API Changes
+
+To support **"Dual Spinlock With Data Group Locking"**, the following changes have been made to the public facing API. These changes are non-breaking, meaning that applications that can build against the existing SMP FreeRTOS kernel will still be able to build even with granular locking enabled (albeit less performant).
+
+The following APIs have been added to enter/exit a critical section in a data group. This are called by FreeRTOS source code to mark critical sections in data groups. However, users can also create their own data groups and enter/exit critical sections in the same manner.
+
+If granular locking is disabled, these macros simply revert to being the standard task enter/exit critical macros.
+
+```c
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define data_groupENTER_CRITICAL()                                    portENTER_CRITICAL_DATA_GROUP( ( portSPINLOCK_TYPE * ) pxTaskSpinlock, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
+    #define data_groupENTER_CRITICAL_FROM_ISR()                           portENTER_CRITICAL_DATA_GROUP_FROM_ISR( ( portSPINLOCK_TYPE * ) pxISRSpinlock )
+    #define data_groupEXIT_CRITICAL()                                     portEXIT_CRITICAL_DATA_GROUP( ( portSPINLOCK_TYPE * ) pxTaskSpinlock, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
+    #define data_groupEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )    portEXIT_CRITICAL_DATA_GROUP_FROM_ISR( uxSavedInterruptStatus, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
+#else /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+    #define data_groupENTER_CRITICAL()                                    taskENTER_CRITICAL()
+    #define data_groupENTER_CRITICAL_FROM_ISR()                           taskENTER_CRITICAL_FROM_ISR()
+    #define data_groupEXIT_CRITICAL()                                     taskEXIT_CRITICAL()
+    #define data_groupEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )    taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+```
+
+In case of the kernel data group (tasks.c), the granular locking macros make use of the existing `vTaskEnter/ExitCritical<FromISR>()` functions to establish critical sections.
+
+
+```c
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define kernelENTER_CRITICAL()                                    vTaskEnterCritical()
+    #define kernelENTER_CRITICAL_FROM_ISR()                           vTaskEnterCriticalFromISR()
+    #define kernelEXIT_CRITICAL()                                     vTaskExitCritical()
+    #define kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )    vTaskExitCriticalFromISR( uxSavedInterruptStatus )
+#else /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+    #define kernelENTER_CRITICAL()                                    taskENTER_CRITICAL()
+    #define kernelENTER_CRITICAL_FROM_ISR()                           taskENTER_CRITICAL_FROM_ISR()
+    #define kernelEXIT_CRITICAL()                                     taskEXIT_CRITICAL()
+    #define kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )    taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+```
+
+The previous critical section macros, viz., `taskENTER/EXIT_CRITICAL()` are still provided and can be called by users. However, FreeRTOS source code will no longer call them. If called by the users, the port should implement a "user" data group. As a result, if an application previously relied on `taskENTER/EXIT_CRITICAL()` for thread safe access to some user data, the same code is still thread safe with granular locking enabled.
+
+```c
+#define taskENTER_CRITICAL()                portENTER_CRITICAL()
+#define taskEXIT_CRITICAL()                 portEXIT_CRITICAL()
+#define taskENTER_CRITICAL_FROM_ISR()       portENTER_CRITICAL_FROM_ISR()
+#define taskEXIT_CRITICAL_FROM_ISR( x )     portEXIT_CRITICAL_FROM_ISR( x )
+```
+
+# Porting Interface
+
+To support **"Dual Spinlock With Data Group Locking"**, ports will need to provide the following macro definitions
+
+## Port Config
+
+The ports will need to provide the following port configuration macros
+
+```c
+#define portUSING_GRANULAR_LOCKS        1   // Enables usage of granular locks
+#define portCRITICAL_NESTING_IN_TCB     0   // Disable critical nesting in TCB. Ports will need to track their own critical nesting
+```
+
+## Spinlocks
+
+Ports will need to provide the following spinlock related macros macros
+
+```c
+/*
+Data type for the port's implementation of a spinlock
+*/
+#define portSPINLOCK_TYPE               port_spinlock_t
+```
+
+Macros are provided for the spinlocks for initializing them either statically or dynamically. This is reflected in the macros API pattern.
+
+```c
+#define portINIT_SPINLOCK( pxSpinlock )    _port_spinlock_init( pxSpinlock )
+#define portINIT__SPINLOCK_STATIC          PORT_SPINLOCK_STATIC_INIT
+```
+
+## Critical Section Macros
+
+The port will need to provide implementations for macros to enter/exit a data group critical section according the procedures described above. Typical implementations of each macro is demonstrated below:
+
+```c
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    #define portENTER_CRITICAL_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )     vPortEnterCriticalDataGroup( pxTaskSpinlock, pxISRSpinlock )
+    #define portENTER_CRITICAL_DATA_GROUP_FROM_ISR( pxISRSpinlock )            uxPortEnterCriticalDataGroupFromISR( pxISRSpinlock )
+    #define portEXIT_CRITICAL_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )      vPortExitCriticalDataGroup( pxTaskSpinlock, pxISRSpinlock )
+    #define portEXIT_CRITICAL_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )          vPortExitCriticalDataGroupFromISR( x, pxISRSpinlock )
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+```
+
+Example implementation of `portENTER_CRITICAL_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )` and `portEXIT_CRITICAL_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )`. Note that:
+
+- `pxTaskSpinlock` is made optional in case users want to create their own data groups that are protected only be a single lock.
+- The kernel implements the `xTaskUnlockCanYield()` function to indicate whether an yield should occur when a critical section exits. This function takes into account whether there are any pending yields and whether preemption is currently disabled.
+
+```c
+void vPortEnterCriticalDataGroup( port_spinlock_t *pxTaskSpinlock, port_spinlock_t *pxISRSpinlock )
+{
+    portDISABLE_INTERRUPTS();
+
+    BaseType_t xCoreID = xPortGetCoreID();
+
+    /* Task spinlock is optional and is always taken first */
+    if( pxTaskSpinlock != NULL )
+    {
+        vPortSpinlockTake( pxTaskSpinlock, portMUX_NO_TIMEOUT );
+        uxCriticalNesting[ xCoreID ]++;
+    }
+
+    /* ISR spinlock must always be provided */
+    vPortSpinlockTake( pxISRSpinlock, portMUX_NO_TIMEOUT );
+    uxCriticalNesting[ xCoreID ]++;
+}
+
+void vPortExitCriticalDataGroup( port_spinlock_t *pxTaskSpinlock, port_spinlock_t *pxISRSpinlock )
+{
+    BaseType_t xCoreID = xPortGetCoreID();
+    BaseType_t xYieldCurrentTask;
+
+    configASSERT( uxCriticalNesting[ xCoreID ] > 0U );
+
+    /* Get the xYieldPending stats inside the critical section. */
+    xYieldCurrentTask = xTaskUnlockCanYield();
+
+    /* ISR spinlock must always be provided */
+    vPortSpinlockRelease( pxISRSpinlock );
+    uxCriticalNesting[ xCoreID ]--;
+
+    /* Task spinlock is optional and is always taken first */
+    if( pxTaskSpinlock != NULL )
+    {
+        vPortSpinlockRelease( pxTaskSpinlock);
+        uxCriticalNesting[ xCoreID ]--;
+    }
+
+    assert(uxCriticalNesting[ xCoreID ] >= 0);
+
+    if( uxCriticalNesting[ xCoreID ] == 0 )
+    {
+        portENABLE_INTERRUPTS();
+
+        /* When a task yields in a critical section it just sets xYieldPending to
+         * true. So now that we have exited the critical section check if xYieldPending
+         * is true, and if so yield. */
+        if( xYieldCurrentTask != pdFALSE )
+        {
+            portYIELD();
+        }
+        else
+        {
+            mtCOVERAGE_TEST_MARKER();
+        }
+    }
+}
+```
+
+Example implementation of `portENTER_CRITICAL_DATA_GROUP_FROM_ISR( pxISRSpinlock )` and `portEXIT_CRITICAL_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )`. Note that only `pxISRSpinlock` needs to be provided since ISR critical sections take a single lock.
+
+```c
+UBaseType_t uxPortLockDataGroupFromISR( port_spinlock_t *pxISRSpinlock )
+{
+    UBaseType_t uxSavedInterruptStatus = 0;
+
+    uxSavedInterruptStatus = portSET_INTERRUPT_MASK_FROM_ISR();
+
+    vPortSpinlockTake( pxISRSpinlock, portMUX_NO_TIMEOUT );
+    uxCriticalNesting[xPortGetCoreID()]++;
+
+    return uxSavedInterruptStatus;
+}
+
+```c
+void vPortUnlockDataGroupFromISR( UBaseType_t uxSavedInterruptStatus, port_spinlock_t *pxISRSpinlock )
+{
+    BaseType_t xCoreID = xPortGetCoreID();
+
+    vPortSpinlockRelease( pxISRSpinlock );
+    uxCriticalNesting[ xCoreID ]--;
+
+    assert(uxCriticalNesting[ xCoreID ] >= 0);
+
+    if( uxCriticalNesting[ xCoreID ] == 0 )
+    {
+        portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus );
+    }
+}
+```
+
+# Source Specific Changes
+
+- Added a `xTaskSpinlock` and `xISRSpinlock` to the data structures of each data group
+- All calls to `taskENTER/EXIT_CRITICAL[_FROM_ISR]()` have been replaced with `data_groupENTER/EXIT_CRITICAL[_FROM_ISR]()`.
+- Added `xTaskUnlockCanYield()` which indicates whether a yield should occur when exiting a critical (i.e., unlocking a data group). Yields should not occur if preemption is disabled (such as when exiting a critical section inside a suspension block).
+
+## Tasks (Kernel Data Group)
+
+- Some functions are called from nested critical sections of other data groups, thus an extra critical section call needs to be added to lock/unlock the kernel data group:
+  - `vTaskInternalSetTimeOutState()`
+  - `xTaskIncrementTick()`
+  - `vTaskSwitchContext()`
+  - `xTaskRemoveFromEventList()`
+  - `vTaskInternalSetTimeOutState()`
+  - `eTaskConfirmSleepModeStatus()`
+  - `xTaskPriorityDisinherit()`
+  - `pvTaskIncrementMutexHeldCount()`
+- Some functions are called from nested suspension blocks of other data gropus, thus an extra suspend/resume call need to be added:
+  - `vTaskPlaceOnEventList()`
+  - `vTaskPlaceOnUnorderedEventList()`
+  - `vTaskPlaceOnEventListRestricted()`
+- `prvCheckForRunStateChange()` has been removed
+- Updated `vTaskSuspendAll()` and `xTaskResumeAll()`
+    - Now holds the `xTaskSpinlock` during kernel suspension
+    - Also increments/decrements `xPreemptionDisable` to prevent yield from occuring when exiting a critical section from inside a kernel suspension block.
+
+## Queue
+
+- Added `queueLOCK()` and `queueUNLOCK()`
+  - If granular locks are disabled, reverts to the previous `prvLockQueue()` and `prvUnlockQueue()`
+  - If granular locks are enabled, will lock/unlock the queue data group for tasks
+
+## Event Groups
+
+- Added `eventLOCK()` and `eventUNLOCK()`
+  - If granular locks are disabled, reverts to the previous `vTaskSuspendAll()` and `xTaskResumeAll()` calls
+  - If granular locks are enabled, will lock/unlock the event groups data group for tasks
+- `xEventGroupSetBits()` and `vEventGroupDelete()` will manually walk the task lists (which belong to the kernel data group). Thus, an extra `vTaskSuspendAll()`/`xTaskResumeAll()` is added to ensure that the kernel data group is suspended while walking those tasks lists.
+
+## Stream Buffer
+
+- Added `sbLOCK()` and `sbUNLOCK()`
+  - If granular locks are disabled, reverts to the previous `vTaskSuspendAll()` and `xTaskResumeAll()` calls
+  - If granular locks are enabled, will lock/unlock the stream buffer data group for tasks
+
+## Timers
+
+- Timers don't have a lock/unlock function. The existing `vTaskSuspendAll()`/`xTaskResumeAll()` calls are valid as they rely on freezing the tick count which is part of the kernel data group.
+
+# Prerequisite Refactoring
+
+A number of refactoring commits have been added to make the addition of granular locking changes simpler:
+
+1. Move critical sections inside `xTaskPriorityInherit()`
+
+Currently, `xTaskPriorityInherit()` is called with wrapping critical sections. The critical sections have now be moved inside the function so that they have access to the kernel data group's spinlocks.
+
+2. Move critical section into `vTaskPriorityDisinheritAfterTimeout()`
+
+Currently, `vTaskPriorityDisinheritAfterTimeout()` is called wrapping critical sections, where the highest priority waiting task is separately obtained via `prvGetDisinheritPriorityAfterTimeout()`. The critical section and checking of the highest priority have been all been moved into `vTaskPriorityDisinheritAfterTimeout()` as all of these operations access the kernel data group.
+
+3. Allow `vTaskPreemptionEnable()` to be nested
+
+Currently, nested calls of `vTaskPreemptionEnable()` is not supported. However, nested calls are required for granular locking due the occurrence of nested suspension across multiple data groups.
+
+Thus, `vTaskPreemptionEnable()` has been updated to support nested calls. This is done by changing `xPreemptionDisable` to a count, where a non-zero count means that the current task cannot be preempted.
+
+# Performance Metrics
+
+Todo
+

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -3179,7 +3179,7 @@ typedef struct xSTATIC_TCB
     #endif
     uint8_t ucDummy7[ configMAX_TASK_NAME_LEN ];
     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-        BaseType_t xDummy25;
+        UBaseType_t xDummy25;
     #endif
     #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
         void * pxDummy8;

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -3238,6 +3238,9 @@ typedef struct xSTATIC_TCB
     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
         UBaseType_t xDummy25;
     #endif
+    #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+        BaseType_t xDummy26;
+    #endif
     #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
         void * pxDummy8;
     #endif

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -451,7 +451,7 @@
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portRELEASE_TASK_LOCK( xCoreID )
     #else
-        #error portRELEASE_TASK_LOCK is required in SMP
+        #error portRELEASE_TASK_LOCK is required in SMP without granular locking feature enabled
     #endif
 
 #endif /* portRELEASE_TASK_LOCK */
@@ -461,7 +461,7 @@
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portGET_TASK_LOCK( xCoreID )
     #else
-        #error portGET_TASK_LOCK is required in SMP
+        #error portGET_TASK_LOCK is required in SMP without granular locking feature enabled
     #endif
 
 #endif /* portGET_TASK_LOCK */
@@ -471,7 +471,7 @@
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portRELEASE_ISR_LOCK( xCoreID )
     #else
-        #error portRELEASE_ISR_LOCK is required in SMP
+        #error portRELEASE_ISR_LOCK is required in SMP without granular locking feature enabled
     #endif
 
 #endif /* portRELEASE_ISR_LOCK */
@@ -481,7 +481,7 @@
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portGET_ISR_LOCK( xCoreID )
     #else
-        #error portGET_ISR_LOCK is required in SMP
+        #error portGET_ISR_LOCK is required in SMP without granular locking feature enabled
     #endif
 
 #endif /* portGET_ISR_LOCK */
@@ -489,7 +489,7 @@
 #ifndef portRELEASE_SPINLOCK
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portRELEASE_SPINLOCK is required for granular locking
+        #error portRELEASE_SPINLOCK is required for SMP with granular locking feature enabled
     #endif
 
 #endif
@@ -497,7 +497,7 @@
 #ifndef portGET_SPINLOCK
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portGET_SPINLOCK is required for granular locking
+        #error portGET_SPINLOCK is required for SMP with granular locking feature enabled
     #endif
 
 #endif
@@ -526,38 +526,6 @@
 
 #endif
 
-#ifndef portENTER_CRITICAL_DATA_GROUP
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portENTER_CRITICAL_DATA_GROUP is required for SMP with granular locking feature enabled
-    #endif
-
-#endif
-
-#ifndef portEXIT_CRITICAL_DATA_GROUP
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portEXIT_CRITICAL_DATA_GROUP is required for SMP with granular locking feature enabled
-    #endif
-
-#endif
-
-#ifndef portENTER_CRITICAL_DATA_GROUP_FROM_ISR
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portENTER_CRITICAL_DATA_GROUP_FROM_ISR is required for SMP with granular locking feature enabled
-    #endif
-
-#endif
-
-#ifndef portEXIT_CRITICAL_DATA_GROUP_FROM_ISR
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portEXIT_CRITICAL_DATA_GROUP_FROM_ISR is required for SMP with granular locking feature enabled
-    #endif
-
-#endif
-
 #ifndef portSPINLOCK_TYPE
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
@@ -566,82 +534,18 @@
 
 #endif
 
-#ifndef portINIT_EVENT_GROUP_TASK_SPINLOCK
+#ifndef portINIT_SPINLOCK
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_EVENT_GROUP_TASK_SPINLOCK is required for granular locking
+        #error portINIT_SPINLOCK is required for SMP with granular locking feature enabled
     #endif
 
 #endif
 
-#ifndef portINIT_EVENT_GROUP_ISR_SPINLOCK
+#ifndef portINIT_SPINLOCK_STATIC
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_EVENT_GROUP_ISR_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_QUEUE_TASK_SPINLOCK
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_QUEUE_TASK_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_QUEUE_ISR_SPINLOCK
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_QUEUE_ISR_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_STREAM_BUFFER_TASK_SPINLOCK
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_STREAM_BUFFER_TASK_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_STREAM_BUFFER_ISR_SPINLOCK
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_STREAM_BUFFER_ISR_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_KERNEL_TASK_SPINLOCK_STATIC
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_KERNEL_TASK_SPINLOCK_STATIC is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_KERNEL_ISR_SPINLOCK_STATIC
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_KERNEL_ISR_SPINLOCK_STATIC is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_TIMERS_TASK_SPINLOCK_STATIC
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_TIMERS_TASK_SPINLOCK_STATIC is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_TIMERS_ISR_SPINLOCK_STATIC
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_TIMERS_ISR_SPINLOCK_STATIC is required for granular locking
+        #error portINIT_SPINLOCK_STATIC is required for SMP with granular locking feature enabled
     #endif
 
 #endif
@@ -3062,7 +2966,7 @@
     #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
     #define portTICK_TYPE_SET_INTERRUPT_MASK_FROM_ISR()         portSET_INTERRUPT_MASK_FROM_ISR()
     #define portTICK_TYPE_CLEAR_INTERRUPT_MASK_FROM_ISR( x )    portCLEAR_INTERRUPT_MASK_FROM_ISR( ( x ) )
-#else
+#else /* if ( portTICK_TYPE_IS_ATOMIC == 0 ) */
 
 /* The tick type can be read atomically, so critical sections used when the
  * tick count is returned can be defined away. */

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -3321,6 +3321,10 @@ typedef struct xSTATIC_QUEUE
         UBaseType_t uxDummy8;
         uint8_t ucDummy9;
     #endif
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        portSPINLOCK_TYPE xDummySpinlock[ 2 ];
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 } StaticQueue_t;
 typedef StaticQueue_t StaticSemaphore_t;
 

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -3354,6 +3354,10 @@ typedef struct xSTATIC_EVENT_GROUP
     #if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
         uint8_t ucDummy4;
     #endif
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        portSPINLOCK_TYPE xDummySpinlock[ 2 ];
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 } StaticEventGroup_t;
 
 /*

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -359,6 +359,10 @@
     #define portCRITICAL_NESTING_IN_TCB    0
 #endif
 
+#ifndef portUSING_GRANULAR_LOCKS
+    #define portUSING_GRANULAR_LOCKS    0
+#endif
+
 #ifndef configMAX_TASK_NAME_LEN
     #define configMAX_TASK_NAME_LEN    16
 #endif
@@ -444,7 +448,7 @@
 
 #ifndef portRELEASE_TASK_LOCK
 
-    #if ( configNUMBER_OF_CORES == 1 )
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portRELEASE_TASK_LOCK( xCoreID )
     #else
         #error portRELEASE_TASK_LOCK is required in SMP
@@ -454,7 +458,7 @@
 
 #ifndef portGET_TASK_LOCK
 
-    #if ( configNUMBER_OF_CORES == 1 )
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portGET_TASK_LOCK( xCoreID )
     #else
         #error portGET_TASK_LOCK is required in SMP
@@ -464,7 +468,7 @@
 
 #ifndef portRELEASE_ISR_LOCK
 
-    #if ( configNUMBER_OF_CORES == 1 )
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portRELEASE_ISR_LOCK( xCoreID )
     #else
         #error portRELEASE_ISR_LOCK is required in SMP
@@ -474,13 +478,37 @@
 
 #ifndef portGET_ISR_LOCK
 
-    #if ( configNUMBER_OF_CORES == 1 )
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portGET_ISR_LOCK( xCoreID )
     #else
         #error portGET_ISR_LOCK is required in SMP
     #endif
 
 #endif /* portGET_ISR_LOCK */
+
+#ifndef portRELEASE_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portRELEASE_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portGET_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portGET_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portCHECK_IF_IN_ISR
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portCHECK_IF_IN_ISR is required for granular locking
+    #endif
+
+#endif
 
 #ifndef portENTER_CRITICAL_FROM_ISR
 
@@ -494,6 +522,126 @@
 
     #if ( configNUMBER_OF_CORES > 1 )
         #error portEXIT_CRITICAL_FROM_ISR is required in SMP
+    #endif
+
+#endif
+
+#ifndef portENTER_CRITICAL_DATA_GROUP
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portENTER_CRITICAL_DATA_GROUP is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portEXIT_CRITICAL_DATA_GROUP
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portEXIT_CRITICAL_DATA_GROUP is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portENTER_CRITICAL_DATA_GROUP_FROM_ISR
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portENTER_CRITICAL_DATA_GROUP_FROM_ISR is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portEXIT_CRITICAL_DATA_GROUP_FROM_ISR
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portEXIT_CRITICAL_DATA_GROUP_FROM_ISR is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portSPINLOCK_TYPE
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portSPINLOCK_TYPE is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portINIT_EVENT_GROUP_TASK_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_EVENT_GROUP_TASK_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_EVENT_GROUP_ISR_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_EVENT_GROUP_ISR_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_QUEUE_TASK_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_QUEUE_TASK_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_QUEUE_ISR_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_QUEUE_ISR_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_STREAM_BUFFER_TASK_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_STREAM_BUFFER_TASK_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_STREAM_BUFFER_ISR_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_STREAM_BUFFER_ISR_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_KERNEL_TASK_SPINLOCK_STATIC
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_KERNEL_TASK_SPINLOCK_STATIC is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_KERNEL_ISR_SPINLOCK_STATIC
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_KERNEL_ISR_SPINLOCK_STATIC is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_TIMERS_TASK_SPINLOCK_STATIC
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_TIMERS_TASK_SPINLOCK_STATIC is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_TIMERS_ISR_SPINLOCK_STATIC
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_TIMERS_ISR_SPINLOCK_STATIC is required for granular locking
     #endif
 
 #endif
@@ -2905,8 +3053,13 @@
 /* Either variables of tick type cannot be read atomically, or
  * portTICK_TYPE_IS_ATOMIC was not set - map the critical sections used when
  * the tick count is returned to the standard critical section macros. */
-    #define portTICK_TYPE_ENTER_CRITICAL()                      portENTER_CRITICAL()
-    #define portTICK_TYPE_EXIT_CRITICAL()                       portEXIT_CRITICAL()
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #define portTICK_TYPE_ENTER_CRITICAL()                  portENTER_CRITICAL_DATA_GROUP( &xTaskSpinlock, &xISRSpinlock )
+        #define portTICK_TYPE_EXIT_CRITICAL()                   portEXIT_CRITICAL_DATA_GROUP( &xTaskSpinlock, &xISRSpinlock )
+    #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+        #define portTICK_TYPE_ENTER_CRITICAL()                  portENTER_CRITICAL()
+        #define portTICK_TYPE_EXIT_CRITICAL()                   portEXIT_CRITICAL()
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
     #define portTICK_TYPE_SET_INTERRUPT_MASK_FROM_ISR()         portSET_INTERRUPT_MASK_FROM_ISR()
     #define portTICK_TYPE_CLEAR_INTERRUPT_MASK_FROM_ISR( x )    portCLEAR_INTERRUPT_MASK_FROM_ISR( ( x ) )
 #else

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -3413,6 +3413,9 @@ typedef struct xSTATIC_STREAM_BUFFER
         void * pvDummy5[ 2 ];
     #endif
     UBaseType_t uxDummy6;
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        portSPINLOCK_TYPE xDummySpinlock[ 2 ];
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 } StaticStreamBuffer_t;
 
 /* Message buffers are built on stream buffers. */

--- a/include/task.h
+++ b/include/task.h
@@ -213,7 +213,7 @@ typedef enum
  * \defgroup taskYIELD taskYIELD
  * \ingroup SchedulerControl
  */
-#define taskYIELD()                                                 portYIELD()
+#define taskYIELD()                          portYIELD()
 
 /**
  * task. h
@@ -227,19 +227,12 @@ typedef enum
  * \defgroup taskENTER_CRITICAL taskENTER_CRITICAL
  * \ingroup SchedulerControl
  */
-#define taskENTER_CRITICAL()                                        portENTER_CRITICAL()
+#define taskENTER_CRITICAL()                 portENTER_CRITICAL()
 #if ( configNUMBER_OF_CORES == 1 )
-    #define taskENTER_CRITICAL_FROM_ISR()                           portSET_INTERRUPT_MASK_FROM_ISR()
+    #define taskENTER_CRITICAL_FROM_ISR()    portSET_INTERRUPT_MASK_FROM_ISR()
 #else
-    #define taskENTER_CRITICAL_FROM_ISR()                           portENTER_CRITICAL_FROM_ISR()
+    #define taskENTER_CRITICAL_FROM_ISR()    portENTER_CRITICAL_FROM_ISR()
 #endif
-#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-    #define taskLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    portLOCK_DATA_GROUP( ( portSPINLOCK_TYPE * ) pxTaskSpinlock, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
-    #define taskLOCK_DATA_GROUP_FROM_ISR( pxISRSpinlock )           portLOCK_DATA_GROUP_FROM_ISR( pxISRSpinlock )
-#else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
-    #define taskLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    taskENTER_CRITICAL()
-    #define taskLOCK_DATA_GROUP_FROM_ISR( pxISRSpinlock )           taskENTER_CRITICAL_FROM_ISR()
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /**
  * task. h
@@ -253,19 +246,12 @@ typedef enum
  * \defgroup taskEXIT_CRITICAL taskEXIT_CRITICAL
  * \ingroup SchedulerControl
  */
-#define taskEXIT_CRITICAL()                                           portEXIT_CRITICAL()
+#define taskEXIT_CRITICAL()                    portEXIT_CRITICAL()
 #if ( configNUMBER_OF_CORES == 1 )
-    #define taskEXIT_CRITICAL_FROM_ISR( x )                           portCLEAR_INTERRUPT_MASK_FROM_ISR( x )
+    #define taskEXIT_CRITICAL_FROM_ISR( x )    portCLEAR_INTERRUPT_MASK_FROM_ISR( x )
 #else
-    #define taskEXIT_CRITICAL_FROM_ISR( x )                           portEXIT_CRITICAL_FROM_ISR( x )
+    #define taskEXIT_CRITICAL_FROM_ISR( x )    portEXIT_CRITICAL_FROM_ISR( x )
 #endif
-#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-    #define taskUNLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    portUNLOCK_DATA_GROUP( ( portSPINLOCK_TYPE * ) pxTaskSpinlock, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
-    #define taskUNLOCK_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )        portUNLOCK_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )
-#else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
-    #define taskUNLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    taskEXIT_CRITICAL()
-    #define taskUNLOCK_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )        taskEXIT_CRITICAL_FROM_ISR( x )
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /**
  * task. h
@@ -3837,7 +3823,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * It should be used in the implementation of portENTER_CRITICAL if port is running a
  * multiple core FreeRTOS.
  */
-#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) || ( configNUMBER_OF_CORES > 1 ) )
     void vTaskEnterCritical( void );
 #endif
 
@@ -3849,7 +3835,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * It should be used in the implementation of portEXIT_CRITICAL if port is running a
  * multiple core FreeRTOS.
  */
-#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) || ( configNUMBER_OF_CORES > 1 ) )
     void vTaskExitCritical( void );
 #endif
 
@@ -3859,7 +3845,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * should be used in the implementation of portENTER_CRITICAL_FROM_ISR if port is
  * running a multiple core FreeRTOS.
  */
-#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
     UBaseType_t vTaskEnterCriticalFromISR( void );
 #endif
 
@@ -3869,12 +3855,12 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * should be used in the implementation of portEXIT_CRITICAL_FROM_ISR if port is
  * running a multiple core FreeRTOS.
  */
-#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
     void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus );
 #endif
 
 /*
- * Checks whether a yield is required after taskUNLOCK_DATA_GROUP() returns.
+ * Checks whether a yield is required after portUNLOCK_DATA_GROUP() returns.
  * To be called while data group is locked.
  */
 #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )

--- a/queue.c
+++ b/queue.c
@@ -1793,11 +1793,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                 {
                     if( pxQueue->uxQueueType == queueQUEUE_IS_MUTEX )
                     {
-                        taskENTER_CRITICAL();
-                        {
-                            xInheritanceOccurred = xTaskPriorityInherit( pxQueue->u.xSemaphore.xMutexHolder );
-                        }
-                        taskEXIT_CRITICAL();
+                        xInheritanceOccurred = xTaskPriorityInherit( pxQueue->u.xSemaphore.xMutexHolder );
                     }
                     else
                     {

--- a/queue.c
+++ b/queue.c
@@ -133,6 +133,11 @@ typedef struct QueueDefinition /* The old naming convention is used to prevent b
         UBaseType_t uxQueueNumber;
         uint8_t ucQueueType;
     #endif
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        portSPINLOCK_TYPE xTaskSpinlock;
+        portSPINLOCK_TYPE xISRSpinlock;
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 } xQUEUE;
 
 /* The old xQUEUE name is maintained above then typedefed to the new Queue_t
@@ -252,11 +257,26 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
 /*-----------------------------------------------------------*/
 
 /*
+ * Macros to mark the start and end of a critical code region.
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define queueENTER_CRITICAL( pxQueue )                                      taskDATA_GROUP_ENTER_CRITICAL( &pxQueue->xTaskSpinlock, &pxQueue->xISRSpinlock )
+    #define queueENTER_CRITICAL_FROM_ISR( pxQueue, puxSavedInterruptStatus )    taskDATA_GROUP_ENTER_CRITICAL_FROM_ISR( &pxQueue->xISRSpinlock, puxSavedInterruptStatus )
+    #define queueEXIT_CRITICAL( pxQueue )                                       taskDATA_GROUP_EXIT_CRITICAL( &pxQueue->xTaskSpinlock, &pxQueue->xISRSpinlock )
+    #define queueEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxQueue )      taskDATA_GROUP_EXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, &pxQueue->xISRSpinlock )
+#else /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+    #define queueENTER_CRITICAL( pxQueue )                                      taskENTER_CRITICAL();
+    #define queueENTER_CRITICAL_FROM_ISR( pxQueue, puxSavedInterruptStatus )    do { *( puxSavedInterruptStatus ) = taskENTER_CRITICAL_FROM_ISR(); } while( 0 )
+    #define queueEXIT_CRITICAL( pxQueue )                                       taskEXIT_CRITICAL();
+    #define queueEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxQueue )      taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/*
  * Macro to mark a queue as locked.  Locking a queue prevents an ISR from
  * accessing the queue event lists.
  */
 #define prvLockQueue( pxQueue )                            \
-    taskENTER_CRITICAL();                                  \
+    queueENTER_CRITICAL( pxQueue );                        \
     {                                                      \
         if( ( pxQueue )->cRxLock == queueUNLOCKED )        \
         {                                                  \
@@ -267,7 +287,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
             ( pxQueue )->cTxLock = queueLOCKED_UNMODIFIED; \
         }                                                  \
     }                                                      \
-    taskEXIT_CRITICAL()
+    queueEXIT_CRITICAL( pxQueue )
 
 /*
  * Macro to increment cTxLock member of the queue data structure. It is
@@ -298,6 +318,57 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
             ( pxQueue )->cRxLock = ( int8_t ) ( ( cRxLock ) + ( int8_t ) 1 ); \
         }                                                                     \
     } while( 0 )
+
+/*
+ * Macro used to lock and unlock a queue. When a task locks a queue, the
+ * task will have thread safe non-deterministic access to the queue.
+ * - Concurrent access from other tasks will be blocked by the xTaskSpinlock
+ * - Concurrent access from ISRs will be pended
+ *
+ * When the tasks unlocks the queue, all pended access attempts are handled.
+ */
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    #define queueLOCK( pxQueue )                                            \
+    do {                                                                    \
+        vTaskPreemptionDisable( NULL );                                     \
+        prvLockQueue( ( pxQueue ) );                                        \
+        portGET_SPINLOCK( portGET_CORE_ID(), &( pxQueue->xTaskSpinlock ) ); \
+    } while( 0 )
+    #define queueUNLOCK( pxQueue, xYieldAPI )                                   \
+    do {                                                                        \
+        prvUnlockQueue( ( pxQueue ) );                                          \
+        portRELEASE_SPINLOCK( portGET_CORE_ID(), &( pxQueue->xTaskSpinlock ) ); \
+        vTaskPreemptionEnable( NULL );                                          \
+        if( ( xYieldAPI ) == pdTRUE )                                           \
+        {                                                                       \
+            taskYIELD_WITHIN_API();                                             \
+        }                                                                       \
+        else                                                                    \
+        {                                                                       \
+            mtCOVERAGE_TEST_MARKER();                                           \
+        }                                                                       \
+    } while( 0 )
+#else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+    #define queueLOCK( pxQueue )     \
+    do {                             \
+        vTaskSuspendAll();           \
+        prvLockQueue( ( pxQueue ) ); \
+    } while( 0 )
+    #define queueUNLOCK( pxQueue, xYieldAPI )                               \
+    do {                                                                    \
+        BaseType_t xAlreadyYielded;                                         \
+        prvUnlockQueue( ( pxQueue ) );                                      \
+        xAlreadyYielded = xTaskResumeAll();                                 \
+        if( ( xAlreadyYielded == pdFALSE ) && ( ( xYieldAPI ) == pdTRUE ) ) \
+        {                                                                   \
+            taskYIELD_WITHIN_API();                                         \
+        }                                                                   \
+        else                                                                \
+        {                                                                   \
+            mtCOVERAGE_TEST_MARKER();                                       \
+        }                                                                   \
+    } while( 0 )
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 /*-----------------------------------------------------------*/
 
 BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
@@ -310,12 +381,22 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
 
     configASSERT( pxQueue );
 
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    {
+        if( xNewQueue == pdTRUE )
+        {
+            portINIT_SPINLOCK( &( pxQueue->xTaskSpinlock ) );
+            portINIT_SPINLOCK( &( pxQueue->xISRSpinlock ) );
+        }
+    }
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
     if( ( pxQueue != NULL ) &&
         ( pxQueue->uxLength >= 1U ) &&
         /* Check for multiplication overflow. */
         ( ( SIZE_MAX / pxQueue->uxLength ) >= pxQueue->uxItemSize ) )
     {
-        taskENTER_CRITICAL();
+        queueENTER_CRITICAL( pxQueue );
         {
             pxQueue->u.xQueue.pcTail = pxQueue->pcHead + ( pxQueue->uxLength * pxQueue->uxItemSize );
             pxQueue->uxMessagesWaiting = ( UBaseType_t ) 0U;
@@ -354,7 +435,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
                 vListInitialise( &( pxQueue->xTasksWaitingToReceive ) );
             }
         }
-        taskEXIT_CRITICAL();
+        queueEXIT_CRITICAL( pxQueue );
     }
     else
     {
@@ -703,7 +784,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
          * calling task is the mutex holder, but not a good way of determining the
          * identity of the mutex holder, as the holder may change between the
          * following critical section exiting and the function returning. */
-        taskENTER_CRITICAL();
+        queueENTER_CRITICAL( pxSemaphore );
         {
             if( pxSemaphore->uxQueueType == queueQUEUE_IS_MUTEX )
             {
@@ -714,7 +795,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
                 pxReturn = NULL;
             }
         }
-        taskEXIT_CRITICAL();
+        queueEXIT_CRITICAL( pxSemaphore );
 
         traceRETURN_xQueueGetMutexHolder( pxReturn );
 
@@ -968,7 +1049,7 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
 
     for( ; ; )
     {
-        taskENTER_CRITICAL();
+        queueENTER_CRITICAL( pxQueue );
         {
             /* Is there room on the queue now?  The running task must be the
              * highest priority task wanting to access the queue.  If the head item
@@ -1074,7 +1155,7 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
                 }
                 #endif /* configUSE_QUEUE_SETS */
 
-                taskEXIT_CRITICAL();
+                queueEXIT_CRITICAL( pxQueue );
 
                 traceRETURN_xQueueGenericSend( pdPASS );
 
@@ -1086,7 +1167,7 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
                 {
                     /* The queue was full and no block time is specified (or
                      * the block time has expired) so leave now. */
-                    taskEXIT_CRITICAL();
+                    queueEXIT_CRITICAL( pxQueue );
 
                     /* Return to the original privilege level before exiting
                      * the function. */
@@ -1109,13 +1190,12 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
                 }
             }
         }
-        taskEXIT_CRITICAL();
+        queueEXIT_CRITICAL( pxQueue );
 
         /* Interrupts and other tasks can send to and receive from the queue
          * now the critical section has been exited. */
 
-        vTaskSuspendAll();
-        prvLockQueue( pxQueue );
+        queueLOCK( pxQueue );
 
         /* Update the timeout state to see if it has expired yet. */
         if( xTaskCheckForTimeOut( &xTimeOut, &xTicksToWait ) == pdFALSE )
@@ -1125,35 +1205,18 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
                 traceBLOCKING_ON_QUEUE_SEND( pxQueue );
                 vTaskPlaceOnEventList( &( pxQueue->xTasksWaitingToSend ), xTicksToWait );
 
-                /* Unlocking the queue means queue events can effect the
-                 * event list. It is possible that interrupts occurring now
-                 * remove this task from the event list again - but as the
-                 * scheduler is suspended the task will go onto the pending
-                 * ready list instead of the actual ready list. */
-                prvUnlockQueue( pxQueue );
-
-                /* Resuming the scheduler will move tasks from the pending
-                 * ready list into the ready list - so it is feasible that this
-                 * task is already in the ready list before it yields - in which
-                 * case the yield will not cause a context switch unless there
-                 * is also a higher priority task in the pending ready list. */
-                if( xTaskResumeAll() == pdFALSE )
-                {
-                    taskYIELD_WITHIN_API();
-                }
+                queueUNLOCK( pxQueue, pdTRUE );
             }
             else
             {
                 /* Try again. */
-                prvUnlockQueue( pxQueue );
-                ( void ) xTaskResumeAll();
+                queueUNLOCK( pxQueue, pdFALSE );
             }
         }
         else
         {
             /* The timeout has expired. */
-            prvUnlockQueue( pxQueue );
-            ( void ) xTaskResumeAll();
+            queueUNLOCK( pxQueue, pdFALSE );
 
             traceQUEUE_SEND_FAILED( pxQueue );
             traceRETURN_xQueueGenericSend( errQUEUE_FULL );
@@ -1203,7 +1266,7 @@ BaseType_t xQueueGenericSendFromISR( QueueHandle_t xQueue,
     /* MISRA Ref 4.7.1 [Return value shall be checked] */
     /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
     /* coverity[misra_c_2012_directive_4_7_violation] */
-    uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
+    queueENTER_CRITICAL_FROM_ISR( pxQueue, &uxSavedInterruptStatus );
     {
         if( ( pxQueue->uxMessagesWaiting < pxQueue->uxLength ) || ( xCopyPosition == queueOVERWRITE ) )
         {
@@ -1328,7 +1391,7 @@ BaseType_t xQueueGenericSendFromISR( QueueHandle_t xQueue,
             xReturn = errQUEUE_FULL;
         }
     }
-    taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+    queueEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxQueue );
 
     traceRETURN_xQueueGenericSendFromISR( xReturn );
 
@@ -1381,7 +1444,7 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
     /* MISRA Ref 4.7.1 [Return value shall be checked] */
     /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
     /* coverity[misra_c_2012_directive_4_7_violation] */
-    uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
+    queueENTER_CRITICAL_FROM_ISR( pxQueue, &uxSavedInterruptStatus );
     {
         const UBaseType_t uxMessagesWaiting = pxQueue->uxMessagesWaiting;
 
@@ -1501,7 +1564,7 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
             xReturn = errQUEUE_FULL;
         }
     }
-    taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+    queueEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxQueue );
 
     traceRETURN_xQueueGiveFromISR( xReturn );
 
@@ -1535,7 +1598,7 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
 
     for( ; ; )
     {
-        taskENTER_CRITICAL();
+        queueENTER_CRITICAL( pxQueue );
         {
             const UBaseType_t uxMessagesWaiting = pxQueue->uxMessagesWaiting;
 
@@ -1567,7 +1630,7 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
                     mtCOVERAGE_TEST_MARKER();
                 }
 
-                taskEXIT_CRITICAL();
+                queueEXIT_CRITICAL( pxQueue );
 
                 traceRETURN_xQueueReceive( pdPASS );
 
@@ -1579,7 +1642,7 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
                 {
                     /* The queue was empty and no block time is specified (or
                      * the block time has expired) so leave now. */
-                    taskEXIT_CRITICAL();
+                    queueEXIT_CRITICAL( pxQueue );
 
                     traceQUEUE_RECEIVE_FAILED( pxQueue );
                     traceRETURN_xQueueReceive( errQUEUE_EMPTY );
@@ -1600,13 +1663,12 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
                 }
             }
         }
-        taskEXIT_CRITICAL();
+        queueEXIT_CRITICAL( pxQueue );
 
         /* Interrupts and other tasks can send to and receive from the queue
          * now the critical section has been exited. */
 
-        vTaskSuspendAll();
-        prvLockQueue( pxQueue );
+        queueLOCK( pxQueue );
 
         /* Update the timeout state to see if it has expired yet. */
         if( xTaskCheckForTimeOut( &xTimeOut, &xTicksToWait ) == pdFALSE )
@@ -1617,31 +1679,20 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
             {
                 traceBLOCKING_ON_QUEUE_RECEIVE( pxQueue );
                 vTaskPlaceOnEventList( &( pxQueue->xTasksWaitingToReceive ), xTicksToWait );
-                prvUnlockQueue( pxQueue );
-
-                if( xTaskResumeAll() == pdFALSE )
-                {
-                    taskYIELD_WITHIN_API();
-                }
-                else
-                {
-                    mtCOVERAGE_TEST_MARKER();
-                }
+                queueUNLOCK( pxQueue, pdTRUE );
             }
             else
             {
                 /* The queue contains data again.  Loop back to try and read the
                  * data. */
-                prvUnlockQueue( pxQueue );
-                ( void ) xTaskResumeAll();
+                queueUNLOCK( pxQueue, pdFALSE );
             }
         }
         else
         {
             /* Timed out.  If there is no data in the queue exit, otherwise loop
              * back and attempt to read the data. */
-            prvUnlockQueue( pxQueue );
-            ( void ) xTaskResumeAll();
+            queueUNLOCK( pxQueue, pdFALSE );
 
             if( prvIsQueueEmpty( pxQueue ) != pdFALSE )
             {
@@ -1688,7 +1739,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
 
     for( ; ; )
     {
-        taskENTER_CRITICAL();
+        queueENTER_CRITICAL( pxQueue );
         {
             /* Semaphores are queues with an item size of 0, and where the
              * number of messages in the queue is the semaphore's count value. */
@@ -1737,7 +1788,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                     mtCOVERAGE_TEST_MARKER();
                 }
 
-                taskEXIT_CRITICAL();
+                queueEXIT_CRITICAL( pxQueue );
 
                 traceRETURN_xQueueSemaphoreTake( pdPASS );
 
@@ -1749,7 +1800,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                 {
                     /* The semaphore count was 0 and no block time is specified
                      * (or the block time has expired) so exit now. */
-                    taskEXIT_CRITICAL();
+                    queueEXIT_CRITICAL( pxQueue );
 
                     traceQUEUE_RECEIVE_FAILED( pxQueue );
                     traceRETURN_xQueueSemaphoreTake( errQUEUE_EMPTY );
@@ -1770,13 +1821,12 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                 }
             }
         }
-        taskEXIT_CRITICAL();
+        queueEXIT_CRITICAL( pxQueue );
 
         /* Interrupts and other tasks can give to and take from the semaphore
          * now the critical section has been exited. */
 
-        vTaskSuspendAll();
-        prvLockQueue( pxQueue );
+        queueLOCK( pxQueue );
 
         /* Update the timeout state to see if it has expired yet. */
         if( xTaskCheckForTimeOut( &xTimeOut, &xTicksToWait ) == pdFALSE )
@@ -1803,30 +1853,19 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                 #endif /* if ( configUSE_MUTEXES == 1 ) */
 
                 vTaskPlaceOnEventList( &( pxQueue->xTasksWaitingToReceive ), xTicksToWait );
-                prvUnlockQueue( pxQueue );
-
-                if( xTaskResumeAll() == pdFALSE )
-                {
-                    taskYIELD_WITHIN_API();
-                }
-                else
-                {
-                    mtCOVERAGE_TEST_MARKER();
-                }
+                queueUNLOCK( pxQueue, pdTRUE );
             }
             else
             {
                 /* There was no timeout and the semaphore count was not 0, so
                  * attempt to take the semaphore again. */
-                prvUnlockQueue( pxQueue );
-                ( void ) xTaskResumeAll();
+                queueUNLOCK( pxQueue, pdFALSE );
             }
         }
         else
         {
             /* Timed out. */
-            prvUnlockQueue( pxQueue );
-            ( void ) xTaskResumeAll();
+            queueUNLOCK( pxQueue, pdFALSE );
 
             /* If the semaphore count is 0 exit now as the timeout has
              * expired.  Otherwise return to attempt to take the semaphore that is
@@ -1841,7 +1880,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                      * test the mutex type again to check it is actually a mutex. */
                     if( xInheritanceOccurred != pdFALSE )
                     {
-                        taskENTER_CRITICAL();
+                        queueENTER_CRITICAL( pxQueue );
                         {
                             UBaseType_t uxHighestWaitingPriority;
 
@@ -1861,7 +1900,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                             /* coverity[overrun] */
                             vTaskPriorityDisinheritAfterTimeout( pxQueue->u.xSemaphore.xMutexHolder, uxHighestWaitingPriority );
                         }
-                        taskEXIT_CRITICAL();
+                        queueEXIT_CRITICAL( pxQueue );
                     }
                 }
                 #endif /* configUSE_MUTEXES */
@@ -1907,7 +1946,7 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
 
     for( ; ; )
     {
-        taskENTER_CRITICAL();
+        queueENTER_CRITICAL( pxQueue );
         {
             const UBaseType_t uxMessagesWaiting = pxQueue->uxMessagesWaiting;
 
@@ -1945,7 +1984,7 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
                     mtCOVERAGE_TEST_MARKER();
                 }
 
-                taskEXIT_CRITICAL();
+                queueEXIT_CRITICAL( pxQueue );
 
                 traceRETURN_xQueuePeek( pdPASS );
 
@@ -1957,7 +1996,7 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
                 {
                     /* The queue was empty and no block time is specified (or
                      * the block time has expired) so leave now. */
-                    taskEXIT_CRITICAL();
+                    queueEXIT_CRITICAL( pxQueue );
 
                     traceQUEUE_PEEK_FAILED( pxQueue );
                     traceRETURN_xQueuePeek( errQUEUE_EMPTY );
@@ -1979,13 +2018,12 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
                 }
             }
         }
-        taskEXIT_CRITICAL();
+        queueEXIT_CRITICAL( pxQueue );
 
         /* Interrupts and other tasks can send to and receive from the queue
          * now that the critical section has been exited. */
 
-        vTaskSuspendAll();
-        prvLockQueue( pxQueue );
+        queueLOCK( pxQueue );
 
         /* Update the timeout state to see if it has expired yet. */
         if( xTaskCheckForTimeOut( &xTimeOut, &xTicksToWait ) == pdFALSE )
@@ -1996,31 +2034,20 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
             {
                 traceBLOCKING_ON_QUEUE_PEEK( pxQueue );
                 vTaskPlaceOnEventList( &( pxQueue->xTasksWaitingToReceive ), xTicksToWait );
-                prvUnlockQueue( pxQueue );
-
-                if( xTaskResumeAll() == pdFALSE )
-                {
-                    taskYIELD_WITHIN_API();
-                }
-                else
-                {
-                    mtCOVERAGE_TEST_MARKER();
-                }
+                queueUNLOCK( pxQueue, pdTRUE );
             }
             else
             {
                 /* There is data in the queue now, so don't enter the blocked
                  * state, instead return to try and obtain the data. */
-                prvUnlockQueue( pxQueue );
-                ( void ) xTaskResumeAll();
+                queueUNLOCK( pxQueue, pdFALSE );
             }
         }
         else
         {
             /* The timeout has expired.  If there is still no data in the queue
              * exit, otherwise go back and try to read the data again. */
-            prvUnlockQueue( pxQueue );
-            ( void ) xTaskResumeAll();
+            queueUNLOCK( pxQueue, pdFALSE );
 
             if( prvIsQueueEmpty( pxQueue ) != pdFALSE )
             {
@@ -2070,7 +2097,7 @@ BaseType_t xQueueReceiveFromISR( QueueHandle_t xQueue,
     /* MISRA Ref 4.7.1 [Return value shall be checked] */
     /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
     /* coverity[misra_c_2012_directive_4_7_violation] */
-    uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
+    queueENTER_CRITICAL_FROM_ISR( pxQueue, &uxSavedInterruptStatus );
     {
         const UBaseType_t uxMessagesWaiting = pxQueue->uxMessagesWaiting;
 
@@ -2130,7 +2157,7 @@ BaseType_t xQueueReceiveFromISR( QueueHandle_t xQueue,
             traceQUEUE_RECEIVE_FROM_ISR_FAILED( pxQueue );
         }
     }
-    taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+    queueEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxQueue );
 
     traceRETURN_xQueueReceiveFromISR( xReturn );
 
@@ -2171,7 +2198,7 @@ BaseType_t xQueuePeekFromISR( QueueHandle_t xQueue,
     /* MISRA Ref 4.7.1 [Return value shall be checked] */
     /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
     /* coverity[misra_c_2012_directive_4_7_violation] */
-    uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
+    queueENTER_CRITICAL_FROM_ISR( pxQueue, &uxSavedInterruptStatus );
     {
         /* Cannot block in an ISR, so check there is data available. */
         if( pxQueue->uxMessagesWaiting > ( UBaseType_t ) 0 )
@@ -2192,7 +2219,7 @@ BaseType_t xQueuePeekFromISR( QueueHandle_t xQueue,
             traceQUEUE_PEEK_FROM_ISR_FAILED( pxQueue );
         }
     }
-    taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+    queueEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxQueue );
 
     traceRETURN_xQueuePeekFromISR( xReturn );
 
@@ -2208,11 +2235,11 @@ UBaseType_t uxQueueMessagesWaiting( const QueueHandle_t xQueue )
 
     configASSERT( xQueue );
 
-    portBASE_TYPE_ENTER_CRITICAL();
+    queueENTER_CRITICAL( xQueue );
     {
         uxReturn = ( ( Queue_t * ) xQueue )->uxMessagesWaiting;
     }
-    portBASE_TYPE_EXIT_CRITICAL();
+    queueEXIT_CRITICAL( xQueue );
 
     traceRETURN_uxQueueMessagesWaiting( uxReturn );
 
@@ -2229,11 +2256,11 @@ UBaseType_t uxQueueSpacesAvailable( const QueueHandle_t xQueue )
 
     configASSERT( pxQueue );
 
-    portBASE_TYPE_ENTER_CRITICAL();
+    queueENTER_CRITICAL( pxQueue );
     {
         uxReturn = ( UBaseType_t ) ( pxQueue->uxLength - pxQueue->uxMessagesWaiting );
     }
-    portBASE_TYPE_EXIT_CRITICAL();
+    queueEXIT_CRITICAL( pxQueue );
 
     traceRETURN_uxQueueSpacesAvailable( uxReturn );
 
@@ -2499,13 +2526,14 @@ static void prvCopyDataFromQueue( Queue_t * const pxQueue,
 
 static void prvUnlockQueue( Queue_t * const pxQueue )
 {
-    /* THIS FUNCTION MUST BE CALLED WITH THE SCHEDULER SUSPENDED. */
+    /* THIS FUNCTION MUST BE CALLED WITH THE SCHEDULER SUSPENDED WHEN portUSING_GRANULAR_LOCKS IS 0.
+     * IT MUST BE CALLED WITH TASK PREEMTION DISABLED WHEN portUSING_GRANULAR_LOCKS IS 1. */
 
     /* The lock counts contains the number of extra data items placed or
      * removed from the queue while the queue was locked.  When a queue is
      * locked items can be added or removed, but the event lists cannot be
      * updated. */
-    taskENTER_CRITICAL();
+    queueENTER_CRITICAL( pxQueue );
     {
         int8_t cTxLock = pxQueue->cTxLock;
 
@@ -2583,10 +2611,10 @@ static void prvUnlockQueue( Queue_t * const pxQueue )
 
         pxQueue->cTxLock = queueUNLOCKED;
     }
-    taskEXIT_CRITICAL();
+    queueEXIT_CRITICAL( pxQueue );
 
     /* Do the same for the Rx lock. */
-    taskENTER_CRITICAL();
+    queueENTER_CRITICAL( pxQueue );
     {
         int8_t cRxLock = pxQueue->cRxLock;
 
@@ -2613,7 +2641,7 @@ static void prvUnlockQueue( Queue_t * const pxQueue )
 
         pxQueue->cRxLock = queueUNLOCKED;
     }
-    taskEXIT_CRITICAL();
+    queueEXIT_CRITICAL( pxQueue );
 }
 /*-----------------------------------------------------------*/
 
@@ -2621,7 +2649,7 @@ static BaseType_t prvIsQueueEmpty( const Queue_t * pxQueue )
 {
     BaseType_t xReturn;
 
-    taskENTER_CRITICAL();
+    queueENTER_CRITICAL( pxQueue );
     {
         if( pxQueue->uxMessagesWaiting == ( UBaseType_t ) 0 )
         {
@@ -2632,7 +2660,7 @@ static BaseType_t prvIsQueueEmpty( const Queue_t * pxQueue )
             xReturn = pdFALSE;
         }
     }
-    taskEXIT_CRITICAL();
+    queueEXIT_CRITICAL( pxQueue );
 
     return xReturn;
 }
@@ -2666,7 +2694,7 @@ static BaseType_t prvIsQueueFull( const Queue_t * pxQueue )
 {
     BaseType_t xReturn;
 
-    taskENTER_CRITICAL();
+    queueENTER_CRITICAL( pxQueue );
     {
         if( pxQueue->uxMessagesWaiting == pxQueue->uxLength )
         {
@@ -2677,7 +2705,7 @@ static BaseType_t prvIsQueueFull( const Queue_t * pxQueue )
             xReturn = pdFALSE;
         }
     }
-    taskEXIT_CRITICAL();
+    queueEXIT_CRITICAL( pxQueue );
 
     return xReturn;
 }
@@ -3157,7 +3185,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
          *  time a yield will be performed.  If an item is added to the queue while
          *  the queue is locked, and the calling task blocks on the queue, then the
          *  calling task will be immediately unblocked when the queue is unlocked. */
-        prvLockQueue( pxQueue );
+        queueLOCK( pxQueue );
 
         if( pxQueue->uxMessagesWaiting == ( UBaseType_t ) 0U )
         {
@@ -3169,7 +3197,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
             mtCOVERAGE_TEST_MARKER();
         }
 
-        prvUnlockQueue( pxQueue );
+        queueUNLOCK( pxQueue, pdFALSE );
 
         traceRETURN_vQueueWaitForMessageRestricted();
     }
@@ -3221,17 +3249,18 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
                                QueueSetHandle_t xQueueSet )
     {
         BaseType_t xReturn;
+        Queue_t * const pxQueue = xQueueOrSemaphore;
 
         traceENTER_xQueueAddToSet( xQueueOrSemaphore, xQueueSet );
 
-        taskENTER_CRITICAL();
+        queueENTER_CRITICAL( pxQueue );
         {
-            if( ( ( Queue_t * ) xQueueOrSemaphore )->pxQueueSetContainer != NULL )
+            if( pxQueue->pxQueueSetContainer != NULL )
             {
                 /* Cannot add a queue/semaphore to more than one queue set. */
                 xReturn = pdFAIL;
             }
-            else if( ( ( Queue_t * ) xQueueOrSemaphore )->uxMessagesWaiting != ( UBaseType_t ) 0 )
+            else if( pxQueue->uxMessagesWaiting != ( UBaseType_t ) 0 )
             {
                 /* Cannot add a queue/semaphore to a queue set if there are already
                  * items in the queue/semaphore. */
@@ -3239,11 +3268,11 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
             }
             else
             {
-                ( ( Queue_t * ) xQueueOrSemaphore )->pxQueueSetContainer = xQueueSet;
+                pxQueue->pxQueueSetContainer = xQueueSet;
                 xReturn = pdPASS;
             }
         }
-        taskEXIT_CRITICAL();
+        queueEXIT_CRITICAL( pxQueue );
 
         traceRETURN_xQueueAddToSet( xReturn );
 
@@ -3277,12 +3306,12 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         }
         else
         {
-            taskENTER_CRITICAL();
+            queueENTER_CRITICAL( pxQueueOrSemaphore );
             {
                 /* The queue is no longer contained in the set. */
                 pxQueueOrSemaphore->pxQueueSetContainer = NULL;
             }
-            taskEXIT_CRITICAL();
+            queueEXIT_CRITICAL( pxQueueOrSemaphore );
             xReturn = pdPASS;
         }
 


### PR DESCRIPTION
This PR adds support for granular locking to the FreeRTOS kernel.

## Description

Granular locking introduces the concept of having localized locks per kernel data group for SMP configuration. This method is an optional replacement of the existing kernel locks and is controlled by a new port layer configuration, viz., portUSING_GRANULAR_LOCKS. More details about the approach can be found [here](https://github.com/sudeep-mohanty/FreeRTOS-Kernel/blob/feature/smp_granular_locks_v4/granular_locks_v4.md).

## Test Steps
The implementation has been tested on Espressif SoC targets, viz., the ESP32 using the ESP-IDF framework.

1. Testing on an esp32 target

To test the implementation of the granular locking scheme on esp32, setup the ESP-IDF environment on your local machine. The steps to follow are listed in the [Getting Started Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html).
Instead of the main ESP-IDF repository, the granular locks implementation resides in this froked repository - https://github.com/sudeep-mohanty/esp-idf.
Once you have cloned the forked repository and setup the ESP-IDF environment, change your branch to [feat/granular_locks_tests](https://github.com/sudeep-mohanty/esp-idf/tree/feat/granular_locks_test).
To run the FreeRTOS unit tests, change the directory to components/freertos/test_apps/freertos where all the test cases are located.
Performance tests are located in the performance subfolder at the same location.
Setup the target device with the command idf.py seet-target esp32.
Select the Amazon FreeRTOS SMP kernel using the menuconfig options. To do this you must enter the command -idf.py menuconfig -> Component config -> FreeRTOS -> Kernel -> Run the Amazon SMP FreeRTOS kernel instead (FEATURE UNDER DEVELOPMENT). Save the configuration and exit the menuconfig.
Now, build and flash the unit test application with the command idf.py build flash monitor.
Once the app is up, you can enter the number of the test case and run the unity test case.

## TODO
 Test setup for other targets (Raspberry Pi Pico)
 Generic target tests to be uploaded to the FreeRTOS repository.

## Checklist:
 I have tested my changes. No regression in existing tests.
 I have modified and/or added unit-tests to cover the code changes in this Pull Request.

## Related Issue
Closes https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/905

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.